### PR TITLE
Create property on Spotlight to allow placeholder overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,12 @@ If you want to translate or change default the placeholder you will need to publ
 php artisan vendor:publish --tag=livewire-ui-spotlight-translations
 ```
 
+You may also change the default placeholder text at runtime
+
+```php
+@livewire('livewire-ui-spotlight', ['placeholderOverride' => 'Some text that overrides the language file.'])
+```
+
 ```php
 <?php
 

--- a/README.md
+++ b/README.md
@@ -389,7 +389,7 @@ php artisan vendor:publish --tag=livewire-ui-spotlight-translations
 You may also change the default placeholder text at runtime
 
 ```php
-@livewire('livewire-ui-spotlight', ['placeholderOverride' => 'Some text that overrides the language file.'])
+@livewire('livewire-ui-spotlight', ['placeholder' => 'Some text that overrides the language file.'])
 ```
 
 ```php

--- a/resources/views/spotlight.blade.php
+++ b/resources/views/spotlight.blade.php
@@ -6,7 +6,7 @@
         <style>{!! file_get_contents($cssPath) !!}</style>
     @endisset
 
-    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ $placeholderOverride ?? trans('livewire-ui-spotlight::spotlight.placeholder') }}', commands: {{ $commands }} })"
+    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ $placeholder ?? trans('livewire-ui-spotlight::spotlight.placeholder') }}', commands: {{ $commands }} })"
          x-init="init()"
          x-show="isOpen"
          x-cloak

--- a/resources/views/spotlight.blade.php
+++ b/resources/views/spotlight.blade.php
@@ -6,7 +6,7 @@
         <style>{!! file_get_contents($cssPath) !!}</style>
     @endisset
 
-    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ trans('livewire-ui-spotlight::spotlight.placeholder') }}', commands: {{ $commands }} })"
+    <div x-data="LivewireUISpotlight({ componentId: '{{ $this->id }}', placeholder: '{{ $placeholderOverride ?? trans('livewire-ui-spotlight::spotlight.placeholder') }}', commands: {{ $commands }} })"
          x-init="init()"
          x-show="isOpen"
          x-cloak

--- a/src/Spotlight.php
+++ b/src/Spotlight.php
@@ -10,6 +10,8 @@ use Livewire\ImplicitlyBoundMethod;
 
 class Spotlight extends Component
 {
+    public string $placeholderOverride;
+
     public static array $commands = [];
 
     public array $dependencyQueryResults = [];

--- a/src/Spotlight.php
+++ b/src/Spotlight.php
@@ -10,7 +10,7 @@ use Livewire\ImplicitlyBoundMethod;
 
 class Spotlight extends Component
 {
-    public string $placeholderOverride;
+    public string $placeholder;
 
     public static array $commands = [];
 


### PR DESCRIPTION
Addresses discussion #56 

Allows for default placeholder setting on page load by just passing in a property in the Livewire component.  API is updated in the README.md  


