### PR TITLE
Use command name instead of class name when creating a command ID

### DIFF
--- a/src/SpotlightCommand.php
+++ b/src/SpotlightCommand.php
@@ -32,6 +32,6 @@ abstract class SpotlightCommand
 
     public function getId(): string
     {
-        return md5(static::class);
+        return md5($this->name);
     }
 }


### PR DESCRIPTION
This PR derives the ID of a command from the command name instead of the class name. #43 presented the idea of adding the same command multiple times with different parameters, however, this does not work due to the ID being the same in every instance. They register fine, but only one is ever callable.

Happy to change this if there are any more thoughts on how to create a unique ID! I presume command names would normally be unique, though.