### PR TITLE
Use @js Livewire directive for correct escaping

### DIFF
--- a/resources/views/spotlight.blade.php
+++ b/resources/views/spotlight.blade.php
@@ -9,7 +9,7 @@
     <div x-data="LivewireUISpotlight({
         componentId: '{{ $this->id }}',
         placeholder: '{{ trans('livewire-ui-spotlight::spotlight.placeholder') }}',
-        commands: {{ $commands }},
+        commands: @js($commands),
         showResultsWithoutInput: '{{ config('livewire-ui-spotlight.show_results_without_input') }}',
     })"
          x-init="init()"


### PR DESCRIPTION
The commands sometimes cause Alpine.js to get confused, using the `@js` directive, these are encoded and parsed properly