### PR TITLE
Fix TailwindCSS issue with `important` option

### DIFF
--- a/resources/views/spotlight.blade.php
+++ b/resources/views/spotlight.blade.php
@@ -13,7 +13,7 @@
         showResultsWithoutInput: '{{ config('livewire-ui-spotlight.show_results_without_input') }}',
     })"
          x-init="init()"
-         x-show="isOpen"
+         x-show.important="isOpen"
          x-cloak
          @foreach(config('livewire-ui-spotlight.shortcuts') as $key)
             @keydown.window.prevent.cmd.{{ $key }}="toggleOpen()"


### PR DESCRIPTION
It's impossible to use Spotlight if your Tailwind configuration uses [the `important` option](https://tailwindcss.com/docs/configuration#important). 

(for those who are not familiar with this option, you can read why it's a good idea to use it in this post by Seb from Spatie https://sebastiandedeyne.com/why-we-use-important-with-tailwind/)

Using [the important modifier on AlpineJS `x-show`](https://alpinejs.dev/directives/show#using-the-important-modifier) fixes this.
