### PR TITLE
Localize command name and description

### DIFF
--- a/src/Spotlight.php
+++ b/src/Spotlight.php
@@ -98,8 +98,8 @@ class Spotlight extends Component
                 ->map(function (SpotlightCommand $command) {
                     return [
                         'id' => $command->getId(),
-                        'name' => $command->getName(),
-                        'description' => $command->getDescription(),
+                        'name' => trans($command->getName()),
+                        'description' => trans($command->getDescription()),
                         'synonyms' => $command->getSynonyms(),
                         'dependencies' => $command->dependencies()?->toArray() ?? [],
                     ];


### PR DESCRIPTION
Using Laravel helper trans() we can now put the $name and $description string values in our lang files and translate them to what we need.